### PR TITLE
Capture and expose Mandrill return value

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: ruby
 rvm:
   - 1.9.3
   - 2.0.0
-  - 2.1.1
-  - 2.1.2
+  - 2.1
 gemfile:
   - gemfiles/rails_30.gemfile
   - gemfiles/rails_31.gemfile

--- a/lib/mandrill_action_mailer/delivery_handler.rb
+++ b/lib/mandrill_action_mailer/delivery_handler.rb
@@ -1,6 +1,6 @@
 module MandrillActionMailer
   class DeliveryHandler
-    attr_accessor :settings
+    attr_accessor :settings, :result
 
     MIME_TYPES = {
       :html => "text/html",
@@ -8,7 +8,10 @@ module MandrillActionMailer
     }.freeze
 
     def initialize(options={})
-      self.settings = { :track_opens => MandrillActionMailer.config.track_opens, :track_clicks => MandrillActionMailer.config.track_clicks }.merge(options)
+      self.settings = {
+        :track_opens => MandrillActionMailer.config.track_opens,
+        :track_clicks => MandrillActionMailer.config.track_clicks
+      }.merge(options)
     end
 
     def deliver!(message)
@@ -38,7 +41,7 @@ module MandrillActionMailer
         message_payload[format] = content.to_s unless content.blank?
       end
 
-      MandrillActionMailer.client.messages.send(message_payload)
+      self.result = MandrillActionMailer.client.messages.send(message_payload)
     end
 
     private

--- a/spec/integration/delivery_handler_spec.rb
+++ b/spec/integration/delivery_handler_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'MandrillActionMailer::DeliverHandler' do
+describe 'MandrillActionMailer::DeliveryHandler' do
   let(:client) { double('Mandrill::API') }
   let(:sender) { double('Mandrill::Messages') }
 
@@ -39,6 +39,25 @@ describe 'MandrillActionMailer::DeliverHandler' do
     expect(sender).to receive(:send)
 
     Notifier.test.deliver
+  end
+
+  context 'delivery method accessors' do
+    before do
+      expect(sender).to receive(:send).and_return 'foo' => 'bar'
+      @mail = Notifier.test.deliver
+    end
+
+    it 'should have settings for `track_opens`' do
+      expect(@mail.delivery_method.settings[:track_opens]).to eq true
+    end
+
+    it 'should have settings for `track_clicks`' do
+      expect(@mail.delivery_method.settings[:track_clicks]).to eq false
+    end
+
+    it 'should have response from mandrill api in `result`' do
+      expect(@mail.delivery_method.result).to eq 'foo' => 'bar'
+    end
   end
 
   it 'should set the subject' do

--- a/spec/rails_app/config/environments/test.rb
+++ b/spec/rails_app/config/environments/test.rb
@@ -30,6 +30,8 @@ TestRailsApp::Application.configure do
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :mandrill
+  config.mandrill_action_mailer.track_opens = true
+  config.mandrill_action_mailer.track_clicks = false
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
Hi, I see this is not a published gem, but the code is clear, you have travis hooked up,  and good tests :)  What are you intentions with this repo?  Do you plan to publish this gem?

If you are interested, this PR adds an attribute to capture the resulting json from the api call which is useful for a variety of scenarios.

In my case, after sending the email, this allows me to look at the `Mail::Message#delivery_method` and see the `result` (and `settings` if you are interested).  The `mail#delivery_method` is an instance of MandrillActionMailer.  Specific changes:
- Add `result` attr_accessor on MandrillActionMailer
- Populate `result` with the return json from mandrill which includes id, status, reject_reason, etc.
- Rename integration test to match handler name
- Set values for track_opens and track_clicks in env and add test to ensure those are set in mailer.

Sample return value from mandrill looks like this:

```
 [
     {
         "email" => "test@test.com",
         "status" => "sent",
         "_id" => "02a8ec384473499ebc338202ecb7ac5b",
         "reject_reason" => null
     }
 ]
```
